### PR TITLE
Contexts

### DIFF
--- a/lib/hey/context.rb
+++ b/lib/hey/context.rb
@@ -1,0 +1,1 @@
+class Hey::Context < OpenStruct; end

--- a/lib/hey/pubsub/event.rb
+++ b/lib/hey/pubsub/event.rb
@@ -28,9 +28,8 @@ class Hey::Pubsub::Event
   end
 
   def metadata
-    merged_data = Hey::ThreadCargo.to_h.merge(@metadata)
-    merged_data.delete(:uuid)
-    merged_data.delete(Hey::ThreadCargo::SANITIZABLE_VALUES_KEY)
+    context_metadata = Hey::ThreadCargo.contexts.reverse.map(&:to_h).reduce(Hash.new, :merge)
+    merged_data = context_metadata.merge(@metadata)
     Hey::SanitizedHash.new(merged_data).to_h
   end
 

--- a/lib/hey/sanitized_hash.rb
+++ b/lib/hey/sanitized_hash.rb
@@ -12,11 +12,13 @@ class Hey::SanitizedHash
   attr_reader :hash
 
   def sanitizable_values
-    @sanitizable_values ||= Hey::ThreadCargo.sanitizable_values.collect { |value| [value, ""] }.to_h
+    @sanitizable_values ||= Hey::ThreadCargo.contexts.map do |context|
+      Array[context[Hey::SANITIZE_KEY]]
+    end.flatten.compact
   end
 
   def sanitize!(value)
-    Hey::ThreadCargo.sanitizable_values.each { |substr| value.to_s.gsub!(substr, "") }
+    sanitizable_values.each { |substr| value.to_s.gsub!(substr, "") }
   end
 
   def traverse(h, &block)

--- a/spec/pubsub/event_spec.rb
+++ b/spec/pubsub/event_spec.rb
@@ -27,22 +27,12 @@ describe Hey::Pubsub::Event do
 
   subject { Hey::Pubsub::Event.new(name: name, metadata: metadata, started_at: started_at, ended_at: ended_at) }
 
-  describe "#to_h" do
+  describe "#metadata" do
     before do
-      Hey::ThreadCargo.set(:current_actor, current_actor)
-      Hey::ThreadCargo.sanitize!("123456")
-    end
-
-    it "adds the current actor" do
-      expect(subject.to_h[:metadata][:current_actor]).to eq(current_actor)
-    end
-
-    it "sets the name" do
-      expect(subject.to_h[:name]).to eq(name)
-    end
-
-    it "adds the uuid" do
-      expect(subject.to_h[:uuid]).to eq(Hey::ThreadCargo.uuid)
+      context = Hey::Context.new(current_actor: current_actor)
+      Hey::ThreadCargo.add_context(context)
+      sanitize_context = Hey::Context.new(sanitize: "123456")
+      Hey::ThreadCargo.add_context(sanitize_context)
     end
 
     it "sanitizes all sanitizable values" do
@@ -63,8 +53,87 @@ describe Hey::Pubsub::Event do
         expect(subject.to_h[:metadata][:http][:request]).to eq("asdsdads?dasdasads&password=123456".gsub("123456", ""))
         expect(subject.to_h[:metadata][:name]).to eq("Chuck D. ")
       end
+
+      it "adds the context metadata" do
+        expect(subject.to_h[:metadata][:current_actor]).to eq(current_actor)
+      end
     end
   end
 
+  describe "#duration" do
+    context "when started at is nil" do
+      it "doesn't attempt to calculate it" do
+        subject.started_at = nil
+        expect(subject.duration).to be_nil
+      end
+    end
 
+    context "when ended at is nil" do
+      it "doesn't attempt to calculate it" do
+        subject.ended_at = nil
+        expect(subject.duration).to be_nil
+      end
+    end
+
+    it "calculates it" do
+      time_as_int = 1438877184
+      subject.started_at = Time.at(time_as_int)
+      subject.ended_at = Time.at(time_as_int + 10)
+      expect(subject.duration).to eq(10000.0)
+    end
+  end
+
+  describe "#started_at" do
+    it "formats it into a string" do
+      subject.started_at = Date.parse("2015-07-07")
+      expect(subject.started_at).to eq("2015-07-07T00:00:00.000")
+    end
+
+    context "when nil" do
+      it "doesn't attempt to format it" do
+        subject.started_at = nil
+        expect(subject.started_at).to be_nil
+      end
+    end
+  end
+
+  describe "#ended_at" do
+    it "formats it into a string" do
+      subject.ended_at = Date.parse("2015-07-07")
+      expect(subject.ended_at).to eq("2015-07-07T00:00:00.000")
+    end
+
+    context "when nil" do
+      it "doesn't attempt to format it" do
+        subject.ended_at = nil
+        expect(subject.ended_at).to be_nil
+      end
+    end
+  end
+
+  describe "#to_h" do
+    it "sets the name" do
+      expect(subject.to_h[:name]).to eq(name)
+    end
+
+    it "adds the uuid" do
+      expect(subject.to_h[:uuid]).to eq(Hey::ThreadCargo.uuid)
+    end
+
+    it "sets the duration" do
+      expect(subject.to_h[:duration]).to_not be_nil
+    end
+
+    it "sets started at" do
+      expect(subject.to_h[:started_at]).to_not be_nil
+    end
+
+    it "sets ended at" do
+      expect(subject.to_h[:ended_at]).to_not be_nil
+    end
+
+    it "sets metadata" do
+      expect(subject.to_h[:metadata]).to_not be_nil
+    end
+  end
 end

--- a/spec/sanitized_hash_spec.rb
+++ b/spec/sanitized_hash_spec.rb
@@ -16,7 +16,8 @@ describe Hey::SanitizedHash do
 
   describe "#to_h" do
     before do
-      Hey::ThreadCargo.sanitize!("123456")
+      sanitize_context = Hey::Context.new(sanitize: "123456")
+      Hey::ThreadCargo.add_context(sanitize_context)
     end
 
     it "sanitizes all sanitizable values" do

--- a/spec/thread_cargo_spec.rb
+++ b/spec/thread_cargo_spec.rb
@@ -5,101 +5,56 @@ describe Hey::ThreadCargo do
     Hey::ThreadCargo.purge!
   end
 
-  describe "#get, #set" do
-    specify do
-      value = "Hello"
-      Hey::ThreadCargo.set(:test_value, value)
-      expect(Hey::ThreadCargo.get(:test_value)).to eq(value)
-    end
-  end
-
-  describe "#uuid" do
+  describe ".uuid" do
     context "when uuid is not set" do
       it "creates a new one" do
         expect(Hey::ThreadCargo.uuid).to_not be_nil
-        expect(Hey::ThreadCargo.get(:uuid)).to_not be_nil
+        expect(Thread.current[:hey][:uuid]).to_not be_nil
       end
     end
   end
 
-  describe "#to_h" do
-    it "returns a hash of values" do
-      Hey::ThreadCargo.set(:test, "test")
-      expect(Hey::ThreadCargo.to_h[:test]).to eq("test")
-    end
-  end
-
-  describe "#purge!" do
+  describe ".purge!" do
     before do
-      Hey::ThreadCargo.set(:name, "Jim Jones")
-      Hey::ThreadCargo.sanitize!("test")
+      Hey::ThreadCargo.uuid
       Hey::ThreadCargo.purge!
     end
 
-    it "unsets the current actor" do
-      expect(Hey::ThreadCargo.get(:name)).to be_nil
-    end
-
-    it "unsets the sanitizable values" do
-      expect(Hey::ThreadCargo.sanitizable_values).to be_empty
+    it "unsets the whole namespace" do
+      expect(Thread.current[:hey]).to be_nil
     end
   end
 
-  describe "#sanitize!, #sanitizable_values" do
-    before do
-      Hey::ThreadCargo.sanitize!(value)
+  describe ".add_contexts" do
+    it "adds a context to the array" do
+      context = Hey::Context.new(foo: "bar")
+      Hey::ThreadCargo.add_context(context)
+      expect(Hey::ThreadCargo.contexts).to include(context)
     end
+  end
 
-    context "when a string" do
-      let(:value) { "test" }
-
-      specify do
-        expect(Hey::ThreadCargo.sanitizable_values).to eq([value])
-      end
+  describe ".remove_contexts" do
+    it "removes a context from the array" do
+      context = Hey::Context.new(foo: "bar")
+      Hey::ThreadCargo.init!
+      Thread.current[:hey][:contexts] = [context]
+      Hey::ThreadCargo.remove_context(context)
+      expect(Hey::ThreadCargo.contexts).to be_empty
     end
+  end
 
-    context "when a an array" do
-      let(:value) { ["test", "Something", "new"] }
-
-      specify do
-        expect(Hey::ThreadCargo.sanitizable_values).to eq(value)
-      end
-    end
-
-    context "when a an array and adding to existing values" do
-      let(:value) { ["test", "Something", "new"] }
-      let(:value2) { ["test2", "Something2", "new2"] }
-
-      before do
-        Hey::ThreadCargo.sanitize!(value2)
-      end
-
-      specify do
-        expect(Hey::ThreadCargo.sanitizable_values).to eq((value + value2).flatten)
+  describe ".contexts" do
+    context "when no contexts have been added" do
+      it "returns an empty array" do
+        expect(Hey::ThreadCargo.contexts).to be_empty
       end
     end
 
-    context "when a string and adding to existing values" do
-      let(:value) { "Hello" }
-      let(:value2) { "Hello2" }
-      before do
-        Hey::ThreadCargo.sanitize!(value2)
-      end
-
-      specify do
-        expect(Hey::ThreadCargo.sanitizable_values).to eq([value, value2])
-      end
-    end
-
-    context "when adding duplicate values" do
-      let(:value) { "Hello" }
-      let(:value2) { "Hello" }
-      before do
-        Hey::ThreadCargo.sanitize!(value2)
-      end
-
-      specify do
-        expect(Hey::ThreadCargo.sanitizable_values).to eq([value])
+    context "when contexts have been added" do
+      it "returns an array of contexts" do
+        context = Hey::Context.new(foo: "bar")
+        Hey::ThreadCargo.add_context(context)
+        expect(Hey::ThreadCargo.contexts).to eq([context])
       end
     end
   end


### PR DESCRIPTION
The previous method of setting global metadata on the thread did not offer an automatic way of purging that data when the logging session was logically terminated.

This PR fundamentally changes the way global metadata is set with the addition of the `Hey.context` method.

All events wrapped in a context call will receive the assigned values. Contexts may also be nested, and events published down the chain will merge all values from the contexts currently in play.

As a context block finishes, it and all its data is removed from the thread. Once the outermost context block completes, the entire `Hey` thread namespace is purged.

The context method also is aware of the special key `:sanitize`, which accepts an array of values that will be sanitized out of any event payloads that are wrapped in the context. Nested contexts will also inherit any sanitized values from their parent contexts.
