### PR TITLE
Namespaces and faraday middleware

### DIFF
--- a/lib/hey.rb
+++ b/lib/hey.rb
@@ -17,9 +17,12 @@ module Hey
     configuration.pubsub_adapter
   end
 
+  def self.global_namespace
+    configuration.global_namespace
+  end
+
   module Behavior
     def publish!(event_name, payload = {}, &block)
-      event_name = "#{Hey.configuration.namespace}.#{event_name}" unless Hey.configuration.namespace.nil?
       event = Hey::Pubsub::Event.new(name: event_name, metadata: payload)
       pubsub_adapter.publish!(event, &block)
     end
@@ -43,6 +46,7 @@ end
 
 require "hey/configuration"
 require "hey/context"
+require "hey/event_name"
 require "hey/thread_cargo"
 require "hey/sanitized_hash"
 require "hey/pubsub"

--- a/lib/hey/configuration.rb
+++ b/lib/hey/configuration.rb
@@ -1,7 +1,8 @@
 class Hey::Configuration
-  attr_accessor :pubsub_adapter, :namespace
+  attr_accessor :pubsub_adapter, :global_namespace, :delimiter
 
   def initialize
     @pubsub_adapter = Hey::Pubsub::Adapters::AsnAdapter
+    @delimiter = ":"
   end
 end

--- a/lib/hey/event_name.rb
+++ b/lib/hey/event_name.rb
@@ -1,0 +1,19 @@
+class Hey::EventName
+  def initialize(name)
+    @name = name
+  end
+
+  def to_s
+    [Hey.global_namespace, namespaces, name].flatten.compact.join(Hey.configuration.delimiter)
+  end
+
+  private
+
+  attr_reader :name
+
+  def namespaces
+    @namespaces ||= Hey::ThreadCargo.contexts.map do |context|
+      Array[context[:namespace]]
+    end.flatten.compact
+  end
+end

--- a/lib/hey/pubsub/event.rb
+++ b/lib/hey/pubsub/event.rb
@@ -3,7 +3,7 @@ class Hey::Pubsub::Event
   attr_accessor :name
 
   def initialize(name:, started_at: nil, ended_at: nil, metadata: {})
-    @name = name
+    @name = Hey::EventName.new(name).to_s
     @started_at = started_at
     @ended_at = ended_at
     @metadata = metadata

--- a/lib/hey/pubsub/middleware/faraday.rb
+++ b/lib/hey/pubsub/middleware/faraday.rb
@@ -1,0 +1,19 @@
+module Hey::Pubsub::Middleware
+  class Faraday
+    def call(env)
+      Hey.publish("request", request: env)
+
+      @app.call(env).on_complete do |env|
+        Hey.publish("response", response: env)
+      end
+    end
+  end
+end
+
+
+
+
+
+
+
+

--- a/spec/event_name_spec.rb
+++ b/spec/event_name_spec.rb
@@ -1,0 +1,43 @@
+require "spec_helper"
+
+describe Hey::SanitizedHash do
+  after do
+    Hey::ThreadCargo.purge!
+  end
+
+  let(:name) { "succeeded" }
+
+  subject { Hey::EventName.new(name) }
+
+  describe "#to_s" do
+    context "when a global namespace is set" do
+      before do
+        Hey.configure do |config|
+          config.global_namespace = "yo"
+        end
+      end
+
+      after do
+        Hey.configure do |config|
+          config.global_namespace = nil
+        end
+      end
+
+      it "adds the global namespace to the name" do
+        expect(subject.to_s).to eq("yo:#{name}")
+      end
+    end
+    context "when namespaces are set" do
+      before do
+        context = Hey::Context.new(namespace: "foo")
+        Hey::ThreadCargo.add_context(context)
+        context = Hey::Context.new(namespace: "bar")
+        Hey::ThreadCargo.add_context(context)
+      end
+
+      it "adds a namespace to the name" do
+        expect(subject.to_s).to eq("foo:bar:#{name}")
+      end
+    end
+  end
+end

--- a/spec/hey_spec.rb
+++ b/spec/hey_spec.rb
@@ -8,7 +8,7 @@ describe Hey do
 
   describe ".pubsub_adapter" do
     it "delegates to configuration" do
-      Hey::Configuration.any_instance.stub(:pubsub_adapter)
+      allow_any_instance_of(Hey::Configuration).to receive(:pubsub_adapter)
       Hey.pubsub_adapter
       expect(Hey.configuration).to have_received(:pubsub_adapter)
     end
@@ -16,7 +16,7 @@ describe Hey do
 
   describe ".subscribe!" do
     it "delegates to the adapter" do
-      Hey.pubsub_adapter.stub(:subscribe!)
+      allow(Hey.pubsub_adapter).to receive(:subscribe!)
       Hey.subscribe!(event_name)
       expect(Hey.pubsub_adapter).to have_received(:subscribe!).with(event_name)
     end
@@ -24,7 +24,7 @@ describe Hey do
 
   describe ".publish!" do
     it "delegates to the adapter" do
-      Hey.pubsub_adapter.stub(:publish!)
+      allow(Hey.pubsub_adapter).to receive(:publish!)
       Hey.publish!(event_name, payload)
       expect(Hey.pubsub_adapter).to have_received(:publish!)
     end


### PR DESCRIPTION
This adds support for chaining namespaces both at a top level and through nested contexts.
### Configuration

A top-level namespace can now be configured:

``` ruby
Hey.configure do |config|
  config.global_namespace = “my-app”
end
```

As can a delimiter for chaining an event name together, the default of which is “:” :

``` ruby
Hey.configure do |config|
  config.delimiter = “/”
end
```

With this configured, and event’s name would look like this:

`my-app/registration/completed`
### Contexts

You can also set a namespace on contexts and they will automatically be chained together in the order they are nested:

``` ruby
Hey.context(namespace: “foo”) do
  Hey.context(namespace: “bar”) do
    Hey.publish!(“hooray”)
  end  
end
```

Which results in: “foo:bar:hooray” when the defaults haven’t been overridden globally.
### Faraday Middleware

This also adds a faraday middleware to broadcast the payloads of all requests and responses.
